### PR TITLE
Add initial workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - run: ./gradle jpackage --info
+      - run: ./gradlew jpackage --info
       - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "12345667" --password "${{ secrets.APPLE_ID_PASSWORD }}"
       - run: xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait
       - run: xcrun notarytool log --keychain-profile "notarytool-profile"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21' ]
+        java: [ '17', '20' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -20,6 +20,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+      - name: Setup macOS key chain
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.OSX_SIGNING_CERT }}
+          p12-password: ${{ secrets.OSX_CERT_PWD }}
+          keychain-password: jabref
+      - name: Setup macOS key chain for app id cert
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.OSX_SIGNING_CERT_APPLICATION }}
+          p12-password: ${{ secrets.OSX_CERT_PWD }}
+          create-keychain: false
+          keychain-password: jabref
       - run: ./gradlew jpackage --info
       - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "12345667" --password "${{ secrets.APPLE_ID_PASSWORD }}"
       - run: xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,8 @@ jobs:
           keychain-password: jabref
       - run: ./gradlew jpackage --info
       - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"
-      - run: xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait
-      - run: xcrun notarytool log --keychain-profile "notarytool-profile"
+      - run: |
+          xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait | tee output.log
+          ID=$(grep 'id:' output.log | head -n 1 | awk '{print $2}')
+          echo $ID
+          xcrun notarytool log --keychain-profile "notarytool-profile" $ID

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '17', '21' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+      - run: ./gradle jpackage --info
+      - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "12345667" --password "${{ secrets.APPLE_ID_PASSWORD }}"
+      - run: xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait
+      - run: xcrun notarytool log --keychain-profile "notarytool-profile"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - run: ./gradle jpackage --info
       - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "12345667" --password "${{ secrets.APPLE_ID_PASSWORD }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: gradle
       - name: Setup macOS key chain
         uses: apple-actions/import-codesign-certs@v2
         with:
@@ -34,6 +35,6 @@ jobs:
           create-keychain: false
           keychain-password: jabref
       - run: ./gradlew jpackage --info
-      - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "12345667" --password "${{ secrets.APPLE_ID_PASSWORD }}"
+      - run: xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"
       - run: xcrun notarytool submit build/distribution/JabRef-1.0.0.dmg --keychain-profile "notarytool-profile" --wait
       - run: xcrun notarytool log --keychain-profile "notarytool-profile"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+This project demonstrates <https://github.com/adoptium/adoptium-support/issues/829>.
+
+For `jpackage`, [The Badass JLink Plugin](https://badass-jlink-plugin.beryx.org/releases/latest/) is used.

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ plugins {
     id 'application'
     id 'org.javamodularity.moduleplugin' version '1.8.12'
 
-    id 'org.openjfx.javafxplugin' version '0.0.14'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
 
-    id 'org.beryx.jlink' version '2.26.0'
+    id 'org.beryx.jlink' version '3.0.0'
 }
 
 group = 'org.jabreftest.test'


### PR DESCRIPTION
This adds an initial workflow. I copied the commands from https://github.com/adoptium/adoptium-support/issues/829#issue-1772838048.

@Siedlerchr could you set the repository secrets `APPLE_ID` and `APPLE_ID_PASSWORD`. Do we also need to update `--mac-signing-key-user-name`?

I also updated the dependencies.