### PR TITLE
Let workflow fail if notarization is invalid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           ID=$(grep 'id:' output.log | head -n 1 | awk '{print $2}')
           echo $ID
           xcrun notarytool log --keychain-profile "notarytool-profile" $ID
+          grep -q "status: Invalid" error.log && exit 1
       - uses: actions/upload-artifact@v3
         with:
           name: dmg-java-${{ matrix.java }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           ID=$(grep 'id:' output.log | head -n 1 | awk '{print $2}')
           echo $ID
           xcrun notarytool log --keychain-profile "notarytool-profile" $ID
-          grep -q "status: Invalid" error.log && exit 1
+          grep -q "status: Invalid" output.log && exit 1
       - uses: actions/upload-artifact@v3
         with:
           name: dmg-java-${{ matrix.java }}


### PR DESCRIPTION
To enable understanding the issue, the workflow should fail on a failing notarization